### PR TITLE
Fix for #1655 : display french help

### DIFF
--- a/libreplan-webapp/pom.xml
+++ b/libreplan-webapp/pom.xml
@@ -125,6 +125,11 @@
                             <copy todir="src/main/webapp/help/it" failonerror="false">
                                 <fileset dir="../doc/src/user/en/html"/>
                             </copy>
+                             <exec executable="make" failifexecutionfails="false">
+                                <arg value="-C"/>
+                                <arg value="../doc/src/user/fr/"/>
+                                <arg value="html"/>
+                            </exec>
                             <copy todir="src/main/webapp/help/fr" failonerror="false">
                                 <fileset dir="../doc/src/user/en/html"/>
                             </copy>


### PR DESCRIPTION
Since the manual had been translated (and updated), it should be displayed for french user.
This fix this problem reported as http://bugs.libreplan.org/show_bug.cgi?id=1655