### PR TITLE
Autofocus on username field at login

### DIFF
--- a/libreplan-webapp/src/main/webapp/common/layout/login.zul
+++ b/libreplan-webapp/src/main/webapp/common/layout/login.zul
@@ -77,7 +77,7 @@
         <n:tr>
           <n:td><label> </label>
               <div align="center">
-                <n:input name="j_username" type="text" class="campotexto" id="textfield" size="30" value="${controller.loginValue}" />
+                <n:input name="j_username" type="text" class="campotexto" id="textfield" size="30" value="${controller.loginValue}" autofocus="autofocus"/>
             </div></n:td>
         </n:tr>
         <n:tr>


### PR DESCRIPTION
It annoyed me that the focus was not on the username field
automatically after loading Libreplan in the browser.