### PR TITLE
Java.lang.NoClassDefFoundError

### DIFF
--- a/libreplan-business/pom.xml
+++ b/libreplan-business/pom.xml
@@ -26,10 +26,6 @@
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-annotations</artifactId>
-        </dependency>
        <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-ehcache</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,6 @@
             </dependency>
             <dependency>
                 <groupId>org.hibernate</groupId>
-                <artifactId>hibernate-annotations</artifactId>
                 <version>3.5.6-Final</version>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -237,11 +237,6 @@
             </dependency>
             <dependency>
                 <groupId>org.hibernate</groupId>
-                <artifactId>hibernate-annotations</artifactId>
-                <version>3.5.6-Final</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-ehcache</artifactId>
                 <version>4.3.4.Final</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,11 @@
             </dependency>
             <dependency>
                 <groupId>org.hibernate</groupId>
+                <artifactId>hibernate-annotations</artifactId>
+                <version>3.5.6-Final</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-ehcache</artifactId>
                 <version>4.3.4.Final</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -237,10 +237,6 @@
             </dependency>
             <dependency>
                 <groupId>org.hibernate</groupId>
-                <version>3.5.6-Final</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-ehcache</artifactId>
                 <version>4.3.4.Final</version>
             </dependency>


### PR DESCRIPTION
When deploying a newly built Libreplan, this error came up on Tomcat
and Glassfish. It seems to be related to Hibernate 4 not needing
Hibernate Annotations anymore. I have removed two references in the
pom.xml files, and the error was gone, while the application still runs