### PR TITLE
ProjectsPlanning WiderNameColumn

### DIFF
--- a/ganttzk/src/main/resources/web/ganttz/zul/leftTasksTree.zul
+++ b/ganttzk/src/main/resources/web/ganttz/zul/leftTasksTree.zul
@@ -26,9 +26,9 @@
 <tree id="tasksTree" fixedLayout="true" sclass="taskTreeCols">
     <treecols sizable="false" height="33px">
         <treecol label="${ganttzk_i18n:_('Name')}" sclass="tree-text" />
-        <treecol label="${ganttzk_i18n:_('Start')}" width="76px" />
-        <treecol label="${ganttzk_i18n:_('End')}" width="76px" />
-        <treecol label="${ganttzk_i18n:_('Status T/M')}" width="76px" />
+        <treecol label="${ganttzk_i18n:_('Start')}" width="60px" />
+        <treecol label="${ganttzk_i18n:_('End')}" width="60px" />
+        <treecol label="${ganttzk_i18n:_('T / M')}" width="55px" />
     </treecols>
 </tree>
 </div>

--- a/ganttzk/src/main/resources/web/ganttz/zul/plannerLayout.zul
+++ b/ganttzk/src/main/resources/web/ganttz/zul/plannerLayout.zul
@@ -102,7 +102,7 @@ planner = self;
 
         <center border="0">
             <borderlayout sclass="plannerlayout_center" height="100%">
-                <west flex="false" collapsible="true" splittable="true" width="300px"
+                <west flex="false" collapsible="true" splittable="true" width="375px"
                     id="taskdetailsContainer" sclass="taskdetailsContainer">
                             <div sclass="leftpanelgap" id="insertionPointLeftPanel"></div>
                 </west>

--- a/pom.xml
+++ b/pom.xml
@@ -237,11 +237,6 @@
             </dependency>
             <dependency>
                 <groupId>org.hibernate</groupId>
-                <artifactId>hibernate-annotations</artifactId>
-                <version>3.5.6-Final</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-ehcache</artifactId>
                 <version>4.3.4.Final</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,11 @@
             </dependency>
             <dependency>
                 <groupId>org.hibernate</groupId>
+                <artifactId>hibernate-annotations</artifactId>
+                <version>3.5.6-Final</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-ehcache</artifactId>
                 <version>4.3.4.Final</version>
             </dependency>


### PR DESCRIPTION
Since T/M column has been added, the Project Name has much less room.
The T/M column and date columns could be less wide (55-60 in stead of
76 pixels), and the total width of the pane has been increased from
300px to 375 pixels.